### PR TITLE
Update PSDecode.psm1

### DIFF
--- a/PSDecode.psm1
+++ b/PSDecode.psm1
@@ -159,7 +159,7 @@ function Base64_Decode {
 
         $b64_decoded_ascii = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($b64_encoded_string))
 
-        if($b64_decoded_ascii -match ‘^(.\x00){8,}’){
+        if($b64_decoded_ascii -match '^(.\x00){8,}'){
             return [System.Text.Encoding]::UNICODE.GetString([System.Convert]::FromBase64String($b64_encoded_string))
             }
         else{


### PR DESCRIPTION
```
At C:\Program Files\WindowsPowerShell\Modules\PSDecode\PSDecode.psm1:162 char:37
+         if($b64_decoded_ascii -match â€˜^(.\x00){8,}â€™){
+                                     ~
You must provide a value expression following the '-match' operator.
```